### PR TITLE
nss: an8855: wire tag_8021q bridging — fix LAN-to-LAN black hole

### DIFF
--- a/nss/overlay/target/linux/qualcommax/files/drivers/net/dsa/an8855.c
+++ b/nss/overlay/target/linux/qualcommax/files/drivers/net/dsa/an8855.c
@@ -327,6 +327,9 @@ static int an8855_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
 				  FIELD_PREP(AN8855_AGE_UNIT, age_unit));
 }
 
+/* Defined with the tag_8021q debug helpers below. */
+static void an8855_tag_8021q_dump_vid(struct an8855_priv *priv, u16 vid);
+
 static int an8855_port_bridge_join(struct dsa_switch *ds, int port,
 				   struct dsa_bridge bridge,
 				   bool *tx_fwd_offload,
@@ -338,6 +341,28 @@ static int an8855_port_bridge_join(struct dsa_switch *ds, int port,
 	ret = an8855_update_port_member(ds, port, bridge.dev, true);
 	if (ret)
 		return ret;
+
+	/* tag_8021q: the port matrix alone cannot bridge user ports. Under
+	 * tag_8021q the VLAN table governs egress, and each port's standalone
+	 * VID only reaches the CPU, while the vsc73xx-8021q RX tagger marks
+	 * bridged-port frames offload_fwd_mark=1 so the software bridge never
+	 * forwards them to sibling ports either - LAN-to-LAN traffic is
+	 * black-holed. Swap the standalone VID for the shared bridge VID
+	 * (cross-adding all bridged ports as members) so the hardware
+	 * genuinely forwards between them, and let *tx_fwd_offload=true make
+	 * the RX mark truthful. Same model as sja1105/vsc73xx.
+	 */
+	ret = dsa_tag_8021q_bridge_join(ds, port, bridge, tx_fwd_offload,
+					extack);
+	if (ret) {
+		an8855_update_port_member(ds, port, bridge.dev, false);
+		return ret;
+	}
+
+	/* DEBUG: show the accumulated bridge-VID membership on the console */
+	mutex_lock(&priv->reg_mutex);
+	an8855_tag_8021q_dump_vid(priv, dsa_tag_8021q_bridge_vid(bridge.num));
+	mutex_unlock(&priv->reg_mutex);
 
 	/* Set to fallback mode for independent VLAN learning if in a bridge */
 	return regmap_update_bits(priv->regmap, AN8855_PCR_P(port),
@@ -351,16 +376,22 @@ static void an8855_port_bridge_leave(struct dsa_switch *ds, int port,
 {
 	struct an8855_priv *priv = ds->priv;
 
+	/* Drop the bridge VID and restore the standalone VID. Via the PVID
+	 * branch of .tag_8021q_vlan_add this also reprograms SECURITY mode +
+	 * standalone PVID - the same isolated tag_8021q state the port had at
+	 * boot. Do NOT force MATRIX (VLAN-unaware) mode afterwards like the
+	 * pre-tag_8021q code did: a standalone port must keep classifying
+	 * untagged ingress into its standalone VID so frames egress the CPU
+	 * port tagged (the conduit tagger needs that VID to demux the port).
+	 */
+	dsa_tag_8021q_bridge_leave(ds, port, bridge);
+
 	an8855_update_port_member(ds, port, bridge.dev, false);
 
-	/* When a port is removed from the bridge, the port would be set up
-	 * back to the default as is at initial boot which is a VLAN-unaware
-	 * port.
-	 */
-	regmap_update_bits(priv->regmap, AN8855_PCR_P(port),
-			   AN8855_PORT_VLAN,
-			   FIELD_PREP(AN8855_PORT_VLAN,
-				      AN8855_PORT_MATRIX_MODE));
+	/* DEBUG: show the shrunk bridge-VID membership on the console */
+	mutex_lock(&priv->reg_mutex);
+	an8855_tag_8021q_dump_vid(priv, dsa_tag_8021q_bridge_vid(bridge.num));
+	mutex_unlock(&priv->reg_mutex);
 }
 
 static int an8855_port_fdb_add(struct dsa_switch *ds, int port,
@@ -1475,10 +1506,29 @@ an8855_setup_pvid_vlan(struct an8855_priv *priv)
  * standalone VID range (0xC00 + port) the VLAN-table validity, VTAG_EN, member
  * mask and per-port egress-tag field. Remove once tag_8021q is confirmed.
  */
+static void an8855_tag_8021q_dump_vid(struct an8855_priv *priv, u16 vid)
+	__must_hold(&priv->reg_mutex)
+{
+	u32 vard;
+
+	if (an8855_vlan_cmd(priv, AN8855_VTCR_RD_VID, vid))
+		return;
+	if (regmap_read(priv->regmap, AN8855_VARD0, &vard))
+		return;
+
+	dev_info(priv->dev,
+		 "tag8021q VID%u: VARD0=%08x valid=%lu vtag_en=%lu members=%02lx etag=%03lx\n",
+		 vid, vard,
+		 (unsigned long)!!(vard & AN8855_VA0_VLAN_VALID),
+		 (unsigned long)!!(vard & AN8855_VA0_VTAG_EN),
+		 FIELD_GET(AN8855_VA0_PORT, vard),
+		 FIELD_GET(AN8855_VA0_ETAG, vard));
+}
+
 static void an8855_tag_8021q_debug_dump(struct an8855_priv *priv)
 {
 	struct dsa_switch *ds = priv->ds;
-	u32 pcr, pvc, pvid, mtx, vard;
+	u32 pcr, pvc, pvid, mtx;
 	int port;
 	u16 vid;
 
@@ -1503,20 +1553,8 @@ static void an8855_tag_8021q_debug_dump(struct an8855_priv *priv)
 	}
 
 	mutex_lock(&priv->reg_mutex);
-	for (vid = 3072; vid < 3072 + AN8855_NUM_PORTS; vid++) {
-		if (an8855_vlan_cmd(priv, AN8855_VTCR_RD_VID, vid))
-			continue;
-		if (regmap_read(priv->regmap, AN8855_VARD0, &vard))
-			continue;
-
-		dev_info(priv->dev,
-			 "tag8021q VID%u: VARD0=%08x valid=%lu vtag_en=%lu members=%02lx etag=%03lx\n",
-			 vid, vard,
-			 (unsigned long)!!(vard & AN8855_VA0_VLAN_VALID),
-			 (unsigned long)!!(vard & AN8855_VA0_VTAG_EN),
-			 FIELD_GET(AN8855_VA0_PORT, vard),
-			 FIELD_GET(AN8855_VA0_ETAG, vard));
-	}
+	for (vid = 3072; vid < 3072 + AN8855_NUM_PORTS; vid++)
+		an8855_tag_8021q_dump_vid(priv, vid);
 	mutex_unlock(&priv->reg_mutex);
 }
 
@@ -1692,6 +1730,15 @@ static int an8855_setup(struct dsa_switch *ds)
 
 	/* Enable assisted learning for fdb isolation */
 	ds->assisted_learning_on_cpu_port = true;
+
+	/* tag_8021q bridging: bridges must get unique nonzero numbers so
+	 * dsa_tag_8021q_bridge_join() derives a distinct bridge VID. DSA only
+	 * hands those out when max_num_bridges is set; otherwise bridge.num
+	 * stays 0 and the "bridge VID" aliases port 0's standalone VID (both
+	 * 3072), which misattributes bridged RX to port 0 and kicks port 0
+	 * out of the bridge VLAN the moment it joins.
+	 */
+	ds->max_num_bridges = DSA_TAG_8021Q_MAX_NUM_BRIDGES;
 
 	/*
 	 * tag_8021q CPU-port egress fix.

--- a/nss/overlay/target/linux/qualcommax/files/drivers/net/dsa/an8855.c
+++ b/nss/overlay/target/linux/qualcommax/files/drivers/net/dsa/an8855.c
@@ -1332,7 +1332,7 @@ static int an8855_tag_8021q_vlan_add(struct dsa_switch *ds, int port, u16 vid,
 		if (ret)
 			return ret;
 
-		ret = an8855_port_set_pvid(priv, port, vid);
+		ret = an8855_port_set_pid(priv, port, vid);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
Addresses #1 — LAN↔LAN traffic black-holed on the NSS build (tag_8021q bridged ports set `offload_fwd_mark` but the hardware never actually forwards between user ports).

## Root cause (confirmed)

Exactly as diagnosed in #1, and verified against the v6.12 DSA sources: each user port only has its standalone tag_8021q VID `{port, CPU4, CPU5}`, so the switch can only forward user traffic to the CPU; meanwhile the `vsc73xx-8021q` RX tagger sets `offload_fwd_mark = !!(dp->bridge)`, and `nbp_switchdev_allowed_egress()` then suppresses the software forward to same-switch sibling ports. Hardware won't, software won't → black hole. Router↔client and client↔WAN traffic never hit this because router-originated frames carry `offload_fwd_mark = 0`.

## The fix (commit 2, `aca4d5d`)

The upstream sja1105/vsc73xx pattern, as proposed in the issue:

- **`an8855_port_bridge_join()`**: call `dsa_tag_8021q_bridge_join()` after the port-matrix update (with rollback on failure). It swaps the port's standalone VID for the shared per-bridge VID — `.tag_8021q_vlan_add` accumulates all bridged ports as members, so the hardware genuinely forwards between them — and sets `*tx_fwd_offload = true`, making the RX `offload_fwd_mark` truthful and letting bridged floods be injected once and replicated by the switch.
- **`an8855_port_bridge_leave()`**: call `dsa_tag_8021q_bridge_leave()`, which restores the standalone VID; its PVID branch reprograms SECURITY mode + standalone PVID. The old forced `AN8855_PORT_MATRIX_MODE` restore is **dropped**: a standalone tag_8021q port must stay VLAN-classifying so untagged ingress lands in its standalone VID and egresses the CPU port tagged (the conduit tagger needs that VID to demux the source port). MATRIX mode would have regressed any port removed from br-lan; the end state now matches a boot-time standalone port (this is also exactly the state the working `wan` port runs in).
- **`an8855_setup()`**: set `ds->max_num_bridges = DSA_TAG_8021Q_MAX_NUM_BRIDGES`.

### Why `max_num_bridges` is load-bearing (gap in the issue's proposed snippet)

`dsa_tag_8021q_bridge_join()` derives the bridge VLAN from `dsa_tag_8021q_bridge_vid(bridge.num)`, and DSA only assigns `bridge.num >= 1` when the driver sets `ds->max_num_bridges` (`net/dsa/port.c: dsa_port_bridge_create()` → `dsa_bridge_num_get()`, which returns 0 when max is 0). Both reference drivers set it (`sja1105_main.c:3162`, `vitesse-vsc73xx-core.c:854`). Without it, `bridge.num` stays 0 and the "bridge VID" is `RSV | VBID(0)` = **3072 — aliasing port 0 (lan4)'s standalone VID**: bridged RX decodes as precise source port 0 (everything misattributed to lan4), and when lan4 itself joins, the join helper's standalone-VID delete removes port 0 from the very VLAN serving as the bridge VLAN — lan4 goes completely dark.

## Preparatory fix (commit 1, `080931b`)

`an8855_tag_8021q_vlan_add()`'s PVID branch called `an8855_port_set_pvid()`, which does not exist — the helper is named `an8855_port_set_pid()`. The kernel builds with `-Werror=implicit-function-declaration`, so **the NSS `an8855.c` at HEAD never compiled**; the flashed images predate the repo export. One-line rename, same signature/semantics.

## Debug visibility

Bridge join/leave now dump the bridge-VID VLAN entry in the same format as the boot-time `an8855_tag_8021q_debug_dump()` (and should be removed together with it once confirmed). Expected on serial as netifd enslaves lan4/lan3/lan2:

```
tag8021q VID3088: ... valid=1 vtag_en=1 members=31 ...   (lan4 + both CPUs)
tag8021q VID3088: ... valid=1 vtag_en=1 members=33 ...   (+ lan3)
tag8021q VID3088: ... valid=1 vtag_en=1 members=37 ...   (+ lan2)
```

(`members` is hex: 0x37 = P0,P1,P2,P4,P5.) The boot dump itself is unchanged — it runs before any bridge joins, so VIDs 3072–3075 still show the standalone layout there. After joins, the standalone VIDs of bridged ports are deleted from the VLAN table (restored on leave) — expected, not a regression.

## Verification done / still needed

Done here:
- Compiled cleanly (zero warnings) against Debian's 6.12.69 kernel headers as an out-of-tree object, with two environment-only shims unrelated to this change (`pcs_inband_caps` is an OpenWrt phylink backport absent from vanilla 6.12; `CONFIG_NET_DSA` is off in Debian's amd64 config).
- All APIs cross-checked character-for-character against v6.12 `include/linux/dsa/8021q.h`, `net/dsa/tag_8021q.c`, `net/dsa/tag_vsc73xx_8021q.c`, `net/dsa/port.c`.
- `an8855_vlan_add()` confirmed to read-modify-write the member mask, so per-port bridge-VID adds accumulate; CPU ports keep refcounted membership until the last port leaves.

Still needed on-device (acceptance criteria from #1):
1. lan2 ↔ lan3 ARP + ping + iperf3 (expect line rate, CPU idle).
2. The three-point `tcpdump` repro from #1 — ARP must now egress lan3.
3. No regression: router↔client, client↔WAN, NSS PPPoE WAN offload throughput (ECM maps interfaces by netdev, not VID, so accelerated flows should be unaffected — but the exceptioned frames ECM learns from now carry the bridge VID, worth a quick `ecm` stats glance).
4. `bridge leave` restore: remove a port from br-lan, confirm it still passes traffic standalone and the join/leave dumps show membership shrink.

Out of scope, unchanged from before: `vlan_filtering=1` on br-lan under tag_8021q (the tagger sends such frames untagged; separate work), and traffic sent directly on a bridged port's own netdev (e.g. an LLDP daemon bound to lanX) now VLAN-misses on the CPU port and falls back to matrix+flood-flag gated delivery — functional, but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY6igFrqW7Y6CJNqCwi3mq
