### PR TITLE
flash safety: refuse in-place sysupgrade + document the initramfs-only NAND path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pure, mainline-based **OpenWrt** for the **Xiaomi AX3000T**, hardware revision *
 | WiFi **2.4 GHz** (IPQ5018) | ✅ |
 | WiFi **5 GHz** (QCN6122) | ✅ |
 | Front status LED (blue/amber) | ✅ |
-| In-place updates via `sysupgrade` | ✅ |
+| Updates via `sysupgrade` (from the RAM-booted initramfs — see below) | ✅ |
 
 > Built against **OpenWrt `25ee126`** (Jul 2026 snapshot, kernel 6.12.94).
 
@@ -52,9 +52,9 @@ Prebuilt images are on the [Releases](../../releases) page:
 
 | File | Purpose |
 |---|---|
-| `…-initramfs-uImage.itb` | Boots OpenWrt entirely in RAM (used during install; never touches flash) |
-| `…-squashfs-sysupgrade.bin` | The permanent image, written to NAND by `sysupgrade` |
-| `…-squashfs-factory.ubi` | Alternative factory image (whole-UBI) |
+| `…-initramfs-uImage.itb` | Boots OpenWrt entirely in RAM. **Required for every flash** — you run `sysupgrade` from this RAM system; it never touches flash by itself |
+| `…-squashfs-sysupgrade.bin` | The permanent image, written to NAND by `sysupgrade` **run from the RAM initramfs above** (not in place — see the warning in step 4) |
+| `…-squashfs-factory.ubi` | Whole-UBI image. **Not used by this guide** — the stock bootloader is locked (no OEM web-flash / no unlocked U-Boot write), so there is no supported way to write it directly. Install via the initramfs + `sysupgrade` path instead |
 
 The install is a **UART + TFTP** procedure because the stock bootloader is locked. Full walkthrough below.
 
@@ -119,11 +119,20 @@ bootm 0x44000000
 OpenWrt boots from RAM. Nothing has been written to flash yet — if anything looks wrong, just power-cycle back to stock.
 
 ### 4. Flash to NAND
+
+> **This RAM-initramfs step is mandatory for every flash — the first install *and* every later update.** It is the only path that yields a bootable image: running `sysupgrade` from the RAM system triggers `xiaomi_initramfs_prepare`, which `ubiformat`s **both** UBI partitions and writes a kernel UBI the locked stock bootloader can actually attach. A plain **in-place** `sysupgrade` from the *installed* NAND system skips that wipe and leaves a UBI that Linux can read but the stock bootloader **cannot** attach (`UBI init error 22`) — an unbootable loop. (`platform.sh` now refuses an in-place `sysupgrade` on this board and points you here.)
+
 On the RAM OpenWrt (root shell on serial, or SSH to `192.168.1.1` once you bring up the LAN), copy the `…squashfs-sysupgrade.bin` onto the device (scp/wget over the LAN), then:
 ```sh
 sysupgrade -n /tmp/openwrt-…-squashfs-sysupgrade.bin
 ```
-Our `platform.sh` case wipes the UBI, writes kernel+rootfs, **and sets the U-Boot boot-flags** (`flag_try_sys{1,2}_failed=8`, etc.) so the stock bootloader boots our slot. It reboots into OpenWrt **from NAND**. Done — the serial cable is no longer required.
+Our `platform.sh` case wipes the UBI, writes kernel+rootfs, **and sets the U-Boot boot-flags** (`flag_try_sys{1,2}_failed=8`, etc.) so the stock bootloader boots our slot. It reboots into OpenWrt **from NAND**. Done — the serial cable is no longer required for normal use.
+
+> ⚠️ **Run `sysupgrade` where it cannot be interrupted** — from the serial console, or a persistent SSH session on the RAM system. **Never wrap it in `timeout`** (or any droppable/killable wrapper): a NAND write torn mid-flight corrupts the kernel UBI and bricks the device the same way (`UBI init error 22`).
+
+**To update later:** repeat steps 3–4 — TFTP-boot the new `…-initramfs-uImage.itb` into RAM, then `sysupgrade` from it. Do **not** `sysupgrade` in place from the running system.
+
+**If you hit a `UBI init error 22` boot loop** (in-place/interrupted flash): it is recoverable, not a hard brick. Repeat steps 3–4 (RAM-boot the initramfs via TFTP, then `sysupgrade -n`); the initramfs path `ubiformat`s and self-heals the corrupt UBI. Worst case, redo the stock TFTP recovery (step 2) and start over.
 
 ### 5. First boot
 - LAN is `192.168.1.1`. Ports `lan2/lan3/lan4` bridge into `br-lan`; the `wan` port is the AN8855's WAN.

--- a/build.sh
+++ b/build.sh
@@ -118,9 +118,9 @@ make -j"$(nproc)"
 echo
 echo "Build complete. Images are in:"
 echo "  $(pwd)/bin/targets/qualcommax/ipq50xx/"
-echo "  - *-initramfs-uImage.itb      (RAM-boot image, flash-safe first test)"
-echo "  - *-squashfs-factory.ubi      (initial NAND install)"
-echo "  - *-squashfs-sysupgrade.bin   (upgrades from OpenWrt)"
+echo "  - *-initramfs-uImage.itb      (RAM-boot image; REQUIRED for every flash — you run sysupgrade from it)"
+echo "  - *-squashfs-sysupgrade.bin   (the NAND image; flash with sysupgrade RUN FROM the initramfs, not in place — see README step 4)"
+echo "  - *-squashfs-factory.ubi      (whole-UBI image; not used on this locked device — install via the initramfs path)"
 if [ "$WITH_NSS" = "1" ]; then
 	echo
 	echo "NSS hardware offload build. After first boot the NSS core boots and"

--- a/files/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/files/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -166,6 +166,27 @@ linksys_mx_pre_upgrade() {
 }
 
 platform_check_image() {
+	case "$(board_name)" in
+	xiaomi,mi-router-ax3000t-v2)
+		# This board stores the kernel in a UBI volume (KERNEL_IN_UBI) and
+		# boots via the locked stock Xiaomi U-Boot. A bootable kernel UBI is
+		# only produced when platform_pre_upgrade -> xiaomi_initramfs_prepare
+		# runs, and that only ubiformats the UBI partitions when the running
+		# rootfs is tmpfs, i.e. when sysupgrade is started from the RAM-booted
+		# initramfs image. An in-place sysupgrade from the installed NAND
+		# system skips that wipe and leaves a UBI that Linux can read but the
+		# stock bootloader cannot attach ("UBI init error 22") -> unbootable.
+		# Refuse it with guidance instead of silently bricking the device.
+		if [ "$(rootfs_type)" != "tmpfs" ]; then
+			v "AX3000T RD03v2: flash to NAND only from a RAM-booted initramfs."
+			v "TFTP-boot the ...-initramfs-uImage.itb (see README), then run"
+			v "sysupgrade from that RAM system. Do NOT sysupgrade in place from"
+			v "the installed system, and never wrap sysupgrade in 'timeout' or a"
+			v "droppable ssh session (a torn NAND write bricks the same way)."
+			return 1
+		fi
+		;;
+	esac
 	return 0;
 }
 


### PR DESCRIPTION
## The problem: the repo hands you a footgun

Building from this repo is fine — `build.sh` + `files/` reproduce a working image (the `KERNEL_IN_UBI` device recipe, `platform.sh` cases, and the u-boot-env entry are all committed; I diffed the working build tree against `files/` and every boot-relevant file is byte-identical). **Producing a NAND-bootable image works.**

What doesn't work is the *install path the docs point you at*. This device (locked stock Xiaomi U-Boot, kernel-in-UBI) can **only** be flashed to NAND from a **RAM-booted initramfs**, because that's the only context where `platform_pre_upgrade → xiaomi_initramfs_prepare` actually runs its `ubiformat` of both UBI partitions:

```sh
xiaomi_initramfs_prepare() {
    [ "$(rootfs_type)" = "tmpfs" ] || return 0   # only wipes when running from initramfs
    ... ubidetach + ubiformat rootfs ; ubidetach + ubiformat ubi_kernel
}
```

`platform_check_image`/`platform_pre_upgrade` run **before** the sysupgrade ramdisk pivot, so `rootfs_type` reflects the *original* root. Run `sysupgrade` **in place from the installed NAND system** and `rootfs_type` is `overlay`, not `tmpfs` → the wipe is skipped → `nand_do_upgrade` writes into the old UBI → the stock bootloader can't attach it (`UBI init error 22`) even though Linux reads it fine → unbootable boot loop. A `sysupgrade` **torn mid-write** (wrapped in `timeout`, or over a droppable SSH) bricks the same way.

Meanwhile the repo actively *invites* the broken path:
- The status table advertised **“In-place updates via `sysupgrade` ✅”**.
- `platform_check_image()` was just `return 0` — **nothing** stopped an in-place flash.
- `factory.ubi` was labelled “initial NAND install” in `build.sh` but “Alternative” in the README, with **no** procedure to write it on this locked device (it was never actually used).

So the obvious action — `sysupgrade image.bin` on a running unit — bricks it. (That's exactly how this was found: an automated flow did precisely that and bricked the test unit; it was recovered over UART/TFTP.)

## What this PR changes

**Safe, high-confidence fixes only** — nothing here can make flashing worse:

- **`platform.sh`** — `platform_check_image()` now **refuses** a flash on this board unless it's running from a tmpfs (initramfs) rootfs, with a message pointing at the correct procedure. Converts a **silent brick into an actionable error** — the key protection for anyone (or any tool) that doesn't read the docs.
- **`README.md`** — corrects the in-place claim; makes the RAM-initramfs step **explicitly mandatory for first install *and* updates**; warns never to wrap `sysupgrade` in `timeout`/a droppable session; documents the `UBI init error 22` recovery (it's recoverable, not a hard brick); fixes the misleading `factory.ubi` labelling.
- **`build.sh`** — post-build image descriptions corrected to match.

## Proposed follow-up (not in this PR — needs a unit to test)

Make in-place `sysupgrade` actually *work* (so the guard could be relaxed): unconditionally `ubidetach`+`ubiformat` the **`ubi_kernel`** partition in `platform_do_upgrade` before `nand_do_upgrade`. `ubi_kernel` holds only the kernel FIT (no persistent data), so wiping it every upgrade yields a clean, stock-U-Boot-attachable kernel UBI regardless of how `sysupgrade` was launched. Left out here because the stock loader's exact UBI intolerance was never fully root-caused and this is untested — it should be validated on a recovered unit first.

## Scope

Independent of the tag_8021q LAN-to-LAN fix (#2) — this is a device-safety/documentation issue for the base and NSS builds alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY6igFrqW7Y6CJNqCwi3mq
